### PR TITLE
Ensure logout script exits after redirect

### DIFF
--- a/admin/logout.php
+++ b/admin/logout.php
@@ -2,3 +2,4 @@
 require_once __DIR__ . '/../includes/bootstrap.php';
 logout();
 header('Location: ' . BASE_URL . 'admin/login.php');
+exit;


### PR DESCRIPTION
## Summary
- Call `exit` after redirect in `admin/logout.php`

## Testing
- `php -l admin/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68aef408d40c832cbd3721a1cb24cf8f