### PR TITLE
Replace placeholder tags for curated section

### DIFF
--- a/public/home.php
+++ b/public/home.php
@@ -476,8 +476,8 @@
             <!-- Curated Gift Boxes Section -->
             <section class="py-16 bg-white">
                 <div class="container mx-auto px-4 text-center">
-                    \1<?= htmlspecialchars(cms_setting("curated_title","Elegant Gifts for Every Celebration")) ?>\2
-                    \1<?= htmlspecialchars(cms_setting("curated_subtitle","Explore premium gift hampers thoughtfully curated to suit every occasion, with gourmet delights, elegant packaging, and a personal touch that makes every gift memorable.")) ?></p>
+                    <h2><?= htmlspecialchars(cms_setting('curated_title', 'Elegant Gifts for Every Celebration')) ?></h2>
+                    <p><?= htmlspecialchars(cms_setting('curated_subtitle', 'Explore premium gift hampers thoughtfully curated to suit every occasion, with gourmet delights, elegant packaging, and a personal touch that makes every gift memorable.')) ?></p>
                     <div class="collection-grid">
                         <!-- Birthday -->
                         <div class="collection-item">


### PR DESCRIPTION
## Summary
- Replace `\1` and `\2` placeholders with `<h2>` and `<p>` tags pulling curated CMS settings on the home page

## Testing
- `php -l public/home.php`


------
https://chatgpt.com/codex/tasks/task_e_68aef40b6984832c94e3d0b6c103dedb