### PR TITLE
chore: point enquiry logo to root homepage

### DIFF
--- a/public/enquiry.php
+++ b/public/enquiry.php
@@ -24,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="text-gray-800">
     <header class="bg-[#efe8e0] p-4 shadow-md">
         <div class="container mx-auto flex justify-between items-center">
-            <a href="home.php" class="text-3xl font-bold text-[#5C817C]">Gifting Stories</a>
+            <a href="/" class="text-3xl font-bold text-[#5C817C]">Gifting Stories</a>
             <nav class="hidden lg:flex space-x-8 items-center">
                 <a href="home.php" class="text-gray-700 hover:text-[#5C817C] transition duration-300">Home</a>
                 <a href="#" class="text-gray-700 hover:text-[#5C817C] transition duration-300">Make Your Own Hamper</a>


### PR DESCRIPTION
## Summary
- load site root when clicking the enquiry page logo instead of home.php

## Testing
- `php -l public/enquiry.php`


------
https://chatgpt.com/codex/tasks/task_e_68af0a0c6fcc832ca385158af8c822ae