### PR TITLE
Add CSRF protection to enquiry form

### DIFF
--- a/public/enquiry.php
+++ b/public/enquiry.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../includes/bootstrap.php';
 
 $submitted = false;
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_verify();
     // Optional: handle enquiry submission (e.g., save to database or send email)
     $submitted = true;
 }
@@ -40,6 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php endif; ?>
         <h1 class="text-2xl font-semibold mb-6 text-center">Send us an Enquiry</h1>
         <form action="/enquiry" method="POST" class="max-w-xl mx-auto space-y-4">
+            <?php csrf_input(); ?>
             <div>
                 <label for="name" class="block text-sm font-medium mb-1">Name</label>
                 <input type="text" id="name" name="name" required class="w-full border border-gray-300 rounded p-2" />


### PR DESCRIPTION
## Summary
- include a hidden CSRF token in the public enquiry form
- verify CSRF token on form submission to block forged requests

## Testing
- `php -l public/enquiry.php`
- `curl -b /tmp/cookie.txt -i -d 'csrf_token=invalid' 127.0.0.1:8001/csrf_test.php` (fails as expected)
- `curl -b /tmp/cookie.txt -i -d "csrf_token=$TOKEN" 127.0.0.1:8001/csrf_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68af0e303700832c855c946262604055