### PR TITLE
Add shared navigation partial

### DIFF
--- a/includes/navigation.php
+++ b/includes/navigation.php
@@ -1,0 +1,22 @@
+<?php
+function cms_get_navigation() {
+    return [
+        'desktop' => [
+            ['label' => 'Home', 'url' => '/'],
+            ['label' => 'Make Your Own Hamper', 'url' => '#'],
+            ['label' => 'About Us', 'url' => '#'],
+            ['label' => 'Contact Us', 'url' => '/#contact'],
+        ],
+        'categories' => [
+            ['label' => 'Diwali Gifts', 'url' => '#'],
+            ['label' => 'Shop Gifts', 'url' => '#'],
+            ['label' => 'Make Your Own Hamper', 'url' => '#'],
+            ['label' => 'All Gifts', 'url' => '#'],
+            ['label' => 'New Arrivals', 'url' => '#'],
+        ],
+        'company' => [
+            ['label' => 'About Us', 'url' => '#'],
+            ['label' => 'Contact Us', 'url' => '/#contact'],
+        ],
+    ];
+}

--- a/public/enquiry.php
+++ b/public/enquiry.php
@@ -12,17 +12,7 @@ $title = 'Enquiry - Gifting Stories';
 require __DIR__ . '/partials/header.php';
 ?>
 <body class="text-gray-800">
-    <header class="bg-[var(--bg-light)] p-4 shadow-md">
-        <div class="container mx-auto flex justify-between items-center">
-            <a href="/" class="text-3xl font-bold text-[var(--primary)]">Gifting Stories</a>
-            <nav class="hidden lg:flex space-x-8 items-center">
-                <a href="/" class="nav-link">Home</a>
-                <a href="#" class="nav-link">Make Your Own Hamper</a>
-                <a href="#" class="nav-link">About Us</a>
-                <a href="/#contact" class="nav-link">Contact Us</a>
-            </nav>
-        </div>
-    </header>
+    <?php require __DIR__ . '/partials/navigation.php'; ?>
 
     <main class="container mx-auto py-10">
         <?php if ($submitted): ?>

--- a/public/home.php
+++ b/public/home.php
@@ -40,64 +40,7 @@ require __DIR__ . '/partials/header.php';
         We do bulk & corporate gifting too. <a href="/enquiry" class="underline hover:text-gray-200">Enquire Now</a>
     </div>
 
-    <!-- Header & Navigation -->
-    <header class="bg-[var(--bg-light)] p-4 shadow-md sticky top-0 z-50">
-        <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
-            <a href="#" class="text-3xl font-bold text-[var(--primary)]" onclick="navigateTo('home')">Gifting Stories</a>
-            <div class="hidden lg:flex space-x-8 items-center">
-                <a href="#" class="nav-link">Make Your Own Hamper</a>
-                <a href="#" class="nav-link">About Us</a>
-                <a href="#" class="nav-link" onclick="navigateTo('contact')">Contact Us</a>
-                <div class="flex space-x-4 items-center text-xl">
-                    <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-search"></i></a>
-                    <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-user"></i></a>
-                    <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-shopping-cart"></i></a>
-                </div>
-            </div>
-            <!-- Mobile Menu Button -->
-            <div class="lg:hidden flex space-x-4 items-center text-xl">
-                <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-search"></i></a>
-                <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-shopping-cart"></i></a>
-                <button id="mobile-menu-button" class="text-gray-700 focus:outline-none">
-                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </header>
-
-    <!-- Mobile Sidebar -->
-    <div id="mobile-sidebar">
-        <div class="flex justify-between items-center p-4 border-b border-gray-200">
-            <h3 class="text-xl font-semibold">Menu</h3>
-            <button id="mobile-close-button" class="text-gray-700 focus:outline-none">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                </svg>
-            </button>
-        </div>
-        <div class="sidebar-buttons">
-            <a href="#" class="sidebar-button-personal">Personal Gifts</a>
-            <a href="#" class="sidebar-button-corporate">Corporate Gifts</a>
-        </div>
-        <h4 class="sidebar-section-title">Shop by Categories</h4>
-        <div class="flex flex-col space-y-2 py-2">
-            <a href="#" class="sidebar-menu-item">Diwali Gifts</a>
-            <a href="#" class="sidebar-menu-item">Shop Gifts</a>
-            <a href="#" class="sidebar-menu-item">Make Your Own Hamper</a>
-            <a href="#" class="sidebar-menu-item">All Gifts</a>
-            <a href="#" class="sidebar-menu-item">New Arrivals</a>
-        </div>
-        <h4 class="sidebar-section-title">Company</h4>
-        <div class="flex flex-col space-y-2 py-2">
-            <a href="#" class="sidebar-menu-item">About Us</a>
-            <a href="#" class="sidebar-menu-item" onclick="navigateTo('contact')">Contact Us</a>
-        </div>
-    </div>
-
-    <!-- Mobile Overlay -->
-    <div id="mobile-overlay"></div>
+    <?php require __DIR__ . '/partials/navigation.php'; ?>
 
     <!-- Page Content Container -->
     <main>

--- a/public/partials/navigation.php
+++ b/public/partials/navigation.php
@@ -1,0 +1,61 @@
+<?php
+require_once __DIR__ . '/../../includes/navigation.php';
+$nav = cms_get_navigation();
+?>
+<!-- Header & Navigation -->
+<header class="bg-[var(--bg-light)] p-4 shadow-md sticky top-0 z-50">
+    <div class="max-w-7xl mx-auto px-4 flex justify-between items-center">
+        <a href="/" class="text-3xl font-bold text-[var(--primary)]">Gifting Stories</a>
+        <div class="hidden lg:flex space-x-8 items-center">
+            <?php foreach ($nav['desktop'] as $link): ?>
+                <a href="<?= htmlspecialchars($link['url']) ?>" class="nav-link"><?= htmlspecialchars($link['label']) ?></a>
+            <?php endforeach; ?>
+            <div class="flex space-x-4 items-center text-xl">
+                <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-search"></i></a>
+                <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-user"></i></a>
+                <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-shopping-cart"></i></a>
+            </div>
+        </div>
+        <!-- Mobile Menu Button -->
+        <div class="lg:hidden flex space-x-4 items-center text-xl">
+            <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-search"></i></a>
+            <a href="#" class="text-gray-700 hover:text-[var(--primary)]"><i class="fas fa-shopping-cart"></i></a>
+            <button id="mobile-menu-button" class="text-gray-700 focus:outline-none">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
+                </svg>
+            </button>
+        </div>
+    </div>
+</header>
+
+<!-- Mobile Sidebar -->
+<div id="mobile-sidebar">
+    <div class="flex justify-between items-center p-4 border-b border-gray-200">
+        <h3 class="text-xl font-semibold">Menu</h3>
+        <button id="mobile-close-button" class="text-gray-700 focus:outline-none">
+            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
+    </div>
+    <div class="sidebar-buttons">
+        <a href="#" class="sidebar-button-personal">Personal Gifts</a>
+        <a href="#" class="sidebar-button-corporate">Corporate Gifts</a>
+    </div>
+    <h4 class="sidebar-section-title">Shop by Categories</h4>
+    <div class="flex flex-col space-y-2 py-2">
+        <?php foreach ($nav['categories'] as $link): ?>
+            <a href="<?= htmlspecialchars($link['url']) ?>" class="sidebar-menu-item"><?= htmlspecialchars($link['label']) ?></a>
+        <?php endforeach; ?>
+    </div>
+    <h4 class="sidebar-section-title">Company</h4>
+    <div class="flex flex-col space-y-2 py-2">
+        <?php foreach ($nav['company'] as $link): ?>
+            <a href="<?= htmlspecialchars($link['url']) ?>" class="sidebar-menu-item"><?= htmlspecialchars($link['label']) ?></a>
+        <?php endforeach; ?>
+    </div>
+</div>
+
+<!-- Mobile Overlay -->
+<div id="mobile-overlay"></div>


### PR DESCRIPTION
## Summary
- add helper returning desktop and mobile navigation links
- introduce reusable navigation partial with header and mobile drawer
- load shared navigation on home and enquiry pages

## Testing
- `php -l includes/navigation.php`
- `php -l public/partials/navigation.php`
- `php -l public/home.php`
- `php -l public/enquiry.php`


------
https://chatgpt.com/codex/tasks/task_e_68b05362ce08832ca83ece44fdef53cd