### PR TITLE
Add hampers dropdown mega-menu and mobile collapsible sections

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -61,6 +61,15 @@
         .nav-link {
             @apply text-gray-700 hover:text-[var(--primary)] transition duration-300 ease-in-out font-medium;
         }
+        .menu-dropdown {
+            @apply grid grid-cols-2 md:grid-cols-3 gap-4 p-4 bg-white border rounded shadow-lg;
+        }
+        .menu-card {
+            @apply flex flex-col items-center text-center p-2 hover:bg-gray-100 rounded transition;
+        }
+        .menu-card img {
+            @apply w-24 h-24 object-cover rounded mb-2;
+        }
         .footer-link {
             @apply text-gray-400 hover:text-white transition duration-300;
         }

--- a/public/partials/navigation.php
+++ b/public/partials/navigation.php
@@ -7,7 +7,32 @@ $nav = cms_get_navigation();
         <a href="/" class="text-3xl font-bold text-[var(--primary)]">Gifting Stories</a>
         <div class="hidden lg:flex space-x-8 items-center">
             <?php foreach ($nav as $item): ?>
-                <?php if (!empty($item['children'])): ?>
+                <?php if (strcasecmp($item['label'], 'Our Products') === 0): ?>
+                    <?php
+                        $hampers = null;
+                        foreach ($item['children'] as $child) {
+                            if (strcasecmp($child['label'], 'Hampers') === 0) {
+                                $hampers = $child;
+                                break;
+                            }
+                        }
+                    ?>
+                    <div class="relative group">
+                        <a href="<?= htmlspecialchars($item['link_url']) ?>" class="nav-link"><?= htmlspecialchars($item['label']) ?></a>
+                        <?php if ($hampers && !empty($hampers['children'])): ?>
+                            <div class="menu-dropdown absolute left-0 mt-2 hidden group-hover:grid">
+                                <?php foreach ($hampers['children'] as $grandchild): ?>
+                                    <a href="<?= htmlspecialchars($grandchild['link_url']) ?>" class="menu-card">
+                                        <?php if (!empty($grandchild['image_url'])): ?>
+                                            <img src="<?= htmlspecialchars($grandchild['image_url']) ?>" alt="<?= htmlspecialchars($grandchild['label']) ?>">
+                                        <?php endif; ?>
+                                        <span><?= htmlspecialchars($grandchild['label']) ?></span>
+                                    </a>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                <?php elseif (!empty($item['children'])): ?>
                     <div class="relative group">
                         <a href="<?= htmlspecialchars($item['link_url']) ?>" class="nav-link"><?= htmlspecialchars($item['label']) ?></a>
                         <div class="absolute left-0 mt-2 hidden group-hover:block bg-white border rounded shadow-lg">
@@ -55,11 +80,38 @@ $nav = cms_get_navigation();
     </div>
     <div class="flex flex-col space-y-2 py-2">
         <?php foreach ($nav as $item): ?>
-            <a href="<?= htmlspecialchars($item['link_url']) ?>" class="sidebar-menu-item"><?= htmlspecialchars($item['label']) ?></a>
-            <?php if (!empty($item['children'])): ?>
-                <?php foreach ($item['children'] as $child): ?>
-                    <a href="<?= htmlspecialchars($child['link_url']) ?>" class="sidebar-menu-item ml-4"><?= htmlspecialchars($child['label']) ?></a>
-                <?php endforeach; ?>
+            <?php if (strcasecmp($item['label'], 'Our Products') === 0): ?>
+                <details>
+                    <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
+                        <?= htmlspecialchars($item['label']) ?>
+                    </summary>
+                    <div class="ml-4">
+                        <?php foreach ($item['children'] as $child): ?>
+                            <?php if (strcasecmp($child['label'], 'Hampers') === 0 && !empty($child['children'])): ?>
+                                <details>
+                                    <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
+                                        <?= htmlspecialchars($child['label']) ?>
+                                    </summary>
+                                    <div class="ml-4">
+                                        <?php foreach ($child['children'] as $grandchild): ?>
+                                            <a href="<?= htmlspecialchars($grandchild['link_url']) ?>" class="sidebar-menu-item">
+                                                <?= htmlspecialchars($grandchild['label']) ?>
+                                            </a>
+                                        <?php endforeach; ?>
+                                    </div>
+                                </details>
+                            <?php else: ?>
+                                <a href="<?= htmlspecialchars($child['link_url']) ?>" class="sidebar-menu-item">
+                                    <?= htmlspecialchars($child['label']) ?>
+                                </a>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                    </div>
+                </details>
+            <?php else: ?>
+                <a href="<?= htmlspecialchars($item['link_url']) ?>" class="sidebar-menu-item">
+                    <?= htmlspecialchars($item['label']) ?>
+                </a>
             <?php endif; ?>
         <?php endforeach; ?>
     </div>


### PR DESCRIPTION
## Summary
- Render Hampers grandchildren in a desktop mega-menu grid with thumbnails
- Mirror Hampers sub-items in mobile sidebar using collapsible details
- Add Tailwind-based styles for `.menu-dropdown` and `.menu-card`

## Testing
- `php -l public/partials/navigation.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b05b65fab8832c8e454e1770d1f492