### PR TITLE
Add menu type support for navigation items

### DIFF
--- a/admin/manage.php
+++ b/admin/manage.php
@@ -55,6 +55,7 @@ $resources = [
       'label'      => ['label' => 'Label', 'type' => 'text'],
       'link_url'   => ['label' => 'Link URL', 'type' => 'text'],
       'image_url'  => ['label' => 'Image URL', 'type' => 'text'],
+      'menu_type'  => ['label' => 'Menu Type', 'type' => 'select', 'options' => ['link' => 'Link', 'dropdown' => 'Dropdown', 'mega' => 'Mega']],
       'parent_id'  => ['label' => 'Parent ID', 'type' => 'number'],
       'sort_order' => ['label' => 'Sort Order', 'type' => 'number'],
       'active'     => ['label' => 'Active', 'type' => 'checkbox'],
@@ -186,6 +187,13 @@ if ($action === 'create' || $action === 'edit') {
         } elseif ($type === 'checkbox') {
             $checked = ((string)$val === '1') ? 'checked' : '';
             echo '<input type="checkbox" name="' . htmlspecialchars($name) . '" value="1" ' . $checked . '>';
+        } elseif ($type === 'select') {
+            echo '<select name="' . htmlspecialchars($name) . '" class="border rounded w-full p-2">';
+            foreach ($meta['options'] as $optVal => $optLabel) {
+                $selected = ($optVal === $val) ? 'selected' : '';
+                echo '<option value="' . htmlspecialchars($optVal) . '" ' . $selected . '>' . htmlspecialchars($optLabel) . '</option>';
+            }
+            echo '</select>';
         } else {
             echo '<input type="' . htmlspecialchars($type) . '" name="' . htmlspecialchars($name) . '" value="' . htmlspecialchars((string)$val) . '" class="border rounded w-full p-2">';
         }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -42,7 +42,7 @@ function cms_get_products() {
 
 function cms_get_navigation() {
     global $pdo;
-    $stmt = $pdo->query('SELECT id, parent_id, label, link_url, image_url FROM navigation_items WHERE active = 1 ORDER BY sort_order ASC, id ASC');
+    $stmt = $pdo->query("SELECT id, parent_id, label, link_url, image_url, menu_type FROM navigation_items WHERE active = 1 ORDER BY sort_order ASC, id ASC");
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     $byId = [];
     foreach ($rows as $row) {

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS navigation_items (
     label VARCHAR(255) NOT NULL,
     link_url VARCHAR(255) DEFAULT NULL,
     image_url VARCHAR(255) DEFAULT NULL,
+    menu_type ENUM('link','dropdown','mega') NOT NULL DEFAULT 'link',
     sort_order INT NOT NULL DEFAULT 0,
     active TINYINT(1) NOT NULL DEFAULT 1,
     CONSTRAINT fk_navigation_parent FOREIGN KEY (parent_id) REFERENCES navigation_items(id) ON DELETE CASCADE

--- a/migrations/seed.sql
+++ b/migrations/seed.sql
@@ -30,12 +30,12 @@ INSERT INTO products (name, description, price, image_url, sort_order, active) V
 ('The Desk Companion','Perfect for a new colleague or a work anniversary.',1500,'https://placehold.co/400x400/D0D0D0/5C817C?text=Product+4',4,1);
 
 -- Navigation menu
-INSERT INTO navigation_items (id, parent_id, label, link_url, image_url, sort_order, active) VALUES
-(1, NULL, 'Home', '/', NULL, 1, 1),
-(2, NULL, 'Shop Gifts', '#', NULL, 2, 1),
-(3, NULL, 'Make Your Own Hamper', '#', NULL, 3, 1),
-(4, NULL, 'About Us', '#', NULL, 4, 1),
-(5, NULL, 'Contact Us', '/#contact', NULL, 5, 1),
-(6, 2, 'Diwali Gifts', '#', NULL, 1, 1),
-(7, 2, 'All Gifts', '#', NULL, 2, 1),
-(8, 2, 'New Arrivals', '#', NULL, 3, 1);
+INSERT INTO navigation_items (id, parent_id, label, link_url, image_url, menu_type, sort_order, active) VALUES
+(1, NULL, 'Home', '/', NULL, 'link', 1, 1),
+(2, NULL, 'Shop Gifts', '#', NULL, 'mega', 2, 1),
+(3, NULL, 'Make Your Own Hamper', '#', NULL, 'link', 3, 1),
+(4, NULL, 'About Us', '#', NULL, 'link', 4, 1),
+(5, NULL, 'Contact Us', '/#contact', NULL, 'link', 5, 1),
+(6, 2, 'Diwali Gifts', '#', NULL, 'link', 1, 1),
+(7, 2, 'All Gifts', '#', NULL, 'link', 2, 1),
+(8, 2, 'New Arrivals', '#', NULL, 'link', 3, 1);

--- a/public/partials/navigation.php
+++ b/public/partials/navigation.php
@@ -7,26 +7,17 @@ $nav = cms_get_navigation();
         <a href="/" class="text-3xl font-bold text-[var(--primary)]">Gifting Stories</a>
         <div class="hidden lg:flex space-x-8 items-center">
             <?php foreach ($nav as $item): ?>
-                <?php if (strcasecmp($item['label'], 'Our Products') === 0): ?>
-                    <?php
-                        $hampers = null;
-                        foreach ($item['children'] as $child) {
-                            if (strcasecmp($child['label'], 'Hampers') === 0) {
-                                $hampers = $child;
-                                break;
-                            }
-                        }
-                    ?>
+                <?php if ($item['menu_type'] === 'mega'): ?>
                     <div class="relative group">
                         <a href="<?= htmlspecialchars($item['link_url']) ?>" class="nav-link"><?= htmlspecialchars($item['label']) ?></a>
-                        <?php if ($hampers && !empty($hampers['children'])): ?>
+                        <?php if (!empty($item['children'])): ?>
                             <div class="menu-dropdown absolute left-0 mt-2 hidden group-hover:grid">
-                                <?php foreach ($hampers['children'] as $grandchild): ?>
-                                    <a href="<?= htmlspecialchars($grandchild['link_url']) ?>" class="menu-card">
-                                        <?php if (!empty($grandchild['image_url'])): ?>
-                                            <img src="<?= htmlspecialchars($grandchild['image_url']) ?>" alt="<?= htmlspecialchars($grandchild['label']) ?>">
+                                <?php foreach ($item['children'] as $child): ?>
+                                    <a href="<?= htmlspecialchars($child['link_url']) ?>" class="menu-card">
+                                        <?php if (!empty($child['image_url'])): ?>
+                                            <img src="<?= htmlspecialchars($child['image_url']) ?>" alt="<?= htmlspecialchars($child['label']) ?>">
                                         <?php endif; ?>
-                                        <span><?= htmlspecialchars($grandchild['label']) ?></span>
+                                        <span><?= htmlspecialchars($child['label']) ?></span>
                                     </a>
                                 <?php endforeach; ?>
                             </div>
@@ -80,14 +71,14 @@ $nav = cms_get_navigation();
     </div>
     <div class="flex flex-col space-y-2 py-2">
         <?php foreach ($nav as $item): ?>
-            <?php if (strcasecmp($item['label'], 'Our Products') === 0): ?>
+            <?php if (!empty($item['children'])): ?>
                 <details>
                     <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
                         <?= htmlspecialchars($item['label']) ?>
                     </summary>
                     <div class="ml-4">
                         <?php foreach ($item['children'] as $child): ?>
-                            <?php if (strcasecmp($child['label'], 'Hampers') === 0 && !empty($child['children'])): ?>
+                            <?php if (!empty($child['children'])): ?>
                                 <details>
                                     <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
                                         <?= htmlspecialchars($child['label']) ?>


### PR DESCRIPTION
## Summary
- add `menu_type` enum column to navigation items schema and seed
- return `menu_type` from `cms_get_navigation`
- allow admins to edit menu type and render mega menu based on it

## Testing
- `php -l admin/manage.php`
- `php -l includes/functions.php`
- `php -l public/partials/navigation.php`


------
https://chatgpt.com/codex/tasks/task_e_68b06426e57c832c8d8e9efd697270d3