### PR TITLE
Handle mega menu type in mobile sidebar

### DIFF
--- a/public/partials/navigation.php
+++ b/public/partials/navigation.php
@@ -71,7 +71,29 @@ $nav = cms_get_navigation();
     </div>
     <div class="flex flex-col space-y-2 py-2">
         <?php foreach ($nav as $item): ?>
-            <?php if (!empty($item['children'])): ?>
+            <?php if ($item['menu_type'] === 'mega'): ?>
+                <details>
+                    <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
+                        <?= htmlspecialchars($item['label']) ?>
+                    </summary>
+                    <div class="ml-4">
+                        <?php foreach ($item['children'] as $child): ?>
+                            <details>
+                                <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
+                                    <?= htmlspecialchars($child['label']) ?>
+                                </summary>
+                                <div class="ml-4">
+                                    <?php foreach ($child['children'] as $grandchild): ?>
+                                        <a href="<?= htmlspecialchars($grandchild['link_url']) ?>" class="sidebar-menu-item">
+                                            <?= htmlspecialchars($grandchild['label']) ?>
+                                        </a>
+                                    <?php endforeach; ?>
+                                </div>
+                            </details>
+                        <?php endforeach; ?>
+                    </div>
+                </details>
+            <?php elseif (!empty($item['children'])): ?>
                 <details>
                     <summary class="sidebar-menu-item cursor-pointer flex justify-between items-center">
                         <?= htmlspecialchars($item['label']) ?>


### PR DESCRIPTION
## Summary
- Render nested `<details>` for children of mega menu items in the mobile sidebar.
- Preserve existing rendering for other menu types.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b07e0d1ed0832cbaa399af3eca1e76